### PR TITLE
Reduced backoff delay (delay too long when CPU enters IDLE mode)

### DIFF
--- a/js/worker/uart.js
+++ b/js/worker/uart.js
@@ -120,8 +120,8 @@ UARTDev.prototype.Reset = function() {
     // Emperically, 1 seems to be best multiplier i.e. no history or ability to 'save up'.
     this.ratelimitmaxcount = ( 1 * this.ratelimitcost) |0;
     
-    //When we stop, we back off for 128 chars-equivalent-time to allow the kernel to catch up
-    this.ratelimitbackoff = -this.ratelimitcost <<7; 
+    //When we stop, we back off for a few chars-equivalent-time to allow the kernel to catch up
+    this.ratelimitbackoff = -this.ratelimitcost <<4; // <<7 was too great a delay when the CPU is in idle mode
     this.ratelimitcounter = 0;
     this.enableratelimitcounter = true; 
 }


### PR DESCRIPTION
This change reduces the backoff time when the Kernel input buffer is full. This 'fixes' the interaction between the CPU going idle and the input buffer becoming full. However this bug means the emulator is entering an IDLE state during the transfer of >4K of uart characters (about 200 lines of printf Hello World). There's two explanations for this: i) The uart is deliberately stalling and input buffer is actually empty and there's nothing todo (this OK, just means that we're not being 100% efficient - which is reasonable because we don't want to loose characters) or, there is a bug in the interrupt logic for going IDLE. For example, the uart never lowers and re-raises the transmit-buffer-empty interrupt because  outgoing characters are immediately consumed. Perhaps this optimization does not interact correctly with the IDLE logic. Can the CPU enter IDLE state if there is an interrupt pending? It probably needs investigating... e.g. Should System.HandleHalt check for pending interrupts?
