### PR TITLE
`npm install` automatically installs browserify and runs ./compile script (step towards using jor1k as a library)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 ehthumbs.db
 Thumbs.db
 .idea/
+node_modules
+utils/fs.json
+utils/fs.xml
+utils/fs
+utils/fs2xml
+utils/packages

--- a/package.json
+++ b/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "jor1k",
+  "version": "1.0.0",
+  "description": "jor1k: OR1000 Javascript Emulator Running Linux",
+  "contributors": [
+    {
+      "name": "Sebastian Macke",
+      "email": "sebastian@macke.de"
+    },
+    {
+      "name": "Gerard Braad",
+      "email": "me@gbraad.nl"
+    },
+    {
+      "name": "Benjamin Burns",
+      "email": "benjamin.c.burns@gmail.com"
+    },
+    {
+      "name": "Lawrence Angrave",
+      "email": "root@localhost"
+    },
+    {
+      "name": "Neelabh Gupta",
+      "email": "nsgupta2@illinois.edu"
+    }
+  ],
+  "keywords": [
+    "or1k",
+    "emulation"
+  ],
+  "author": "Sebastian Macke",
+  "license": "simplified BSD",
+  "bugs": {
+    "url": "https://github.com/s-macke/jor1k/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/s-macke/jor1k.git"
+  },
+  "main": "index.html",
+  "dependencies": {},
+  "devDependencies": {
+    "jshint": "latest",
+    "browserify": "^8.0.3"
+  },
+  "scripts": {
+    "postinstall": "./compile"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  }
+}


### PR DESCRIPTION
+ added downloaded and generated package files to .gitignore
+ re-added package.json
+ added all contributors from readme to package.json
+ added browserisfy as dev dependency in package.json
+ run ./compile as post-install step
+ set npm package version to 1.0.0 ([here's](https://docs.npmjs.com/getting-started/semantic-versioning
) why)