### PR TITLE
Modualize terminals, pluginize terminal emulator, add term.js

### DIFF
--- a/compile
+++ b/compile
@@ -1,3 +1,3 @@
-browserify -r ./js/master/master.js:Jor1k -o jor1k-master-min.js
+browserify -r ./js/plugins/terminal-macke.js:MackeTerm -r ./js/plugins/terminal-termjs.js:TermJSTerm -r ./js/master/master.js:Jor1k -o jor1k-master-min.js
 browserify js/worker/worker.js -o jor1k-worker-min.js
 

--- a/compile.html
+++ b/compile.html
@@ -122,6 +122,8 @@ function Start() {
 
     var userid = RandomString(10);
 
+    var MackeTerm = require("MackeTerm");
+
     jor1kparameters = {
         system: {
             kernelURL: "bin/vmlinux.bin.bz2", // kernel image
@@ -145,7 +147,7 @@ function Start() {
             lazyloadimages: [
             ] // list of automatically loaded images after the basic filesystem has been loaded
         },
-        termid: "tty",   // canvas id for the terminal
+        term: new MackeTerm("tty"),   // canvas id for the terminal
         fbid: "fb",     // canvas id for the framebuffer
         clipboardid: "clipboard",  // input id for the clipboard
         statsid: "stats",  // object id for the statistics test

--- a/demos/simple.html
+++ b/demos/simple.html
@@ -11,8 +11,9 @@
 <script>
 
 var Jor1k = require("Jor1k");
+var MackeTerm = require("MackeTerm");
 
-jor1kgui = new Jor1k({termid: "tty", path: "../"});
+jor1kgui = new Jor1k({term: new MackeTerm("tty"), path: "../"});
 
 </script>
 

--- a/index.html
+++ b/index.html
@@ -171,6 +171,8 @@ function Start() {
 
     var userid = RandomString(10);
 
+    var MackeTerm = require("MackeTerm");
+
     jor1kparameters = {
         system: {
             kernelURL: "bin/vmlinux.bin.bz2", // kernel image
@@ -186,7 +188,7 @@ function Start() {
             ] // list of automatically loaded images after the basic filesystem has been loaded
 	},
 
-        termid: "tty",             // canvas id for the terminal
+        term: new MackeTerm("tty"),             // canvas id for the terminal
         fbid: "fb",                // canvas id for the framebuffer
         clipboardid: "clipboard",  // input id for the clipboard
         statsid: "stats",          // object id for the statistics test

--- a/js/plugins/terminal-macke.js
+++ b/js/plugins/terminal-macke.js
@@ -1,0 +1,30 @@
+var Terminal = require("../master/dev/terminal");
+
+function MackeTerm(termid) {
+    this.termid = termid;
+}
+
+MackeTerm.prototype.Init = function(jor1kGUI) {
+    this.term = new Terminal(24, 80, this.termid);
+    jor1kGUI.message.Register("tty0", function(d) {
+       d.forEach(function(c) {
+           this.term.PutChar(c&0xFF);
+       }.bind(this));
+    }.bind(this));
+
+    this.terminalcanvas = document.getElementById(this.termid);
+    this.terminalcanvas.onmousedown = function(event) {
+        if (!jor1kGUI.framebuffer) return;
+        jor1kGUI.framebuffer.fbcanvas.style.border = "2px solid #000000";
+    }.bind(this);
+}
+
+MackeTerm.prototype.WasHitByEvent = function(evt) {
+    return this.terminalcanvas.contains(evt.target);
+}
+
+MackeTerm.prototype.PauseBlink = function(pause) {
+    this.term.PauseBlink(pause);
+}
+
+module.exports = MackeTerm;

--- a/js/plugins/terminal-termjs.js
+++ b/js/plugins/terminal-termjs.js
@@ -1,0 +1,40 @@
+var TermJS = require("./term.js");
+var UTF8 = require("../lib/utf8");
+
+function TermJSTerm(termElement) {
+    this.termElement = termElement;
+    this.utf8converter = new UTF8.UTF8StreamToUnicode();
+}
+
+TermJSTerm.prototype.Init = function(jor1kGUI) {
+    this.term = new TermJS({ cols: 80, rows: 24, screenKeys: true, useStyle: true, cursorBlink: false });
+    this.term.on("keypress", function(key, ev) {
+        if (ev)
+            jor1kGUI.terminput.OnKeyPress(ev);
+    });
+    this.term.on("keydown", function(key, ev) {
+        if (ev)
+            jor1kGUI.terminput.OnKeyDown(ev);
+    });
+    this.term.open(this.termElement);
+    jor1kGUI.message.Register("tty0", function(d) {
+        //this.term.write(String.fromCharCode.apply(null, d)); // TODO Unicode
+        for (var i of d) {
+            var c = this.utf8converter.Put(i);
+            if (c != -1) this.term.write(String.fromCharCode(c));
+        }
+    }.bind(this));
+}
+
+TermJSTerm.prototype.WasHitByEvent = function(evt) {
+    return this.termElement.contains(evt.target);
+}
+
+TermJSTerm.prototype.PauseBlink = function(pause) {
+    this.term.cursorBlink = !pause;
+    if (!pause) {
+         this.term.startBlink();
+    }
+}
+
+module.exports = TermJSTerm;


### PR DESCRIPTION
This improved upon pull request #47 with the proposed changes and also handles Unicode correctly. It addresses issue #46 .

It still requires patched term.js with the following patch:

```diff
diff --git a/src/term.js b/src/term.js
index f26617d..c061e36 100644
--- a/src/term.js
+++ b/src/term.js
@@ -464,9 +464,9 @@ Terminal.prototype.initGlobal = function() {
   }
   Terminal._boundDocs.push(document);
 
-  Terminal.bindPaste(document);
+  //Terminal.bindPaste(document);
 
-  Terminal.bindKeys(document);
+  //Terminal.bindKeys(document);
 
   Terminal.bindCopy(document);
 
