### PR TITLE
refactoring: created facade for CPU implementations + tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,16 @@
+{
+  "globals"   : {
+    "setTimeout": false,
+    "clearTimeout": false,
+    "require"   : false,
+    "ArrayBuffer": false,
+    "Uint8Array": false,
+    "Int8Array": false,
+    "Uint16Array": false,
+    "Int16Array": false,
+    "Uint32Array": false,
+    "Int32Array": false,
+    "Float32Array": false,
+    "module": false
+  }
+}

--- a/js/master/system.js
+++ b/js/master/system.js
@@ -94,7 +94,7 @@ function jor1kGUI(parameters)
    this.IgnoreKeys = function() {
       return (
           (this.lastMouseDownTarget != TERMINAL) &&
-          (this.lastMouseDownTarget != this.framebuffer.fbcanvas) &&
+          (this.framebuffer && this.lastMouseDownTarget != this.framebuffer.fbcanvas) &&
           (this.lastMouseDownTarget != this.clipboard)
       );
     }

--- a/js/worker/cpu/index.js
+++ b/js/worker/cpu/index.js
@@ -1,0 +1,217 @@
+/* this is a unified, abstract interface (a facade) to the different
+ * CPU implementations
+ */
+
+"use strict";
+var message = require('../messagehandler'); // global variable
+var imul = require('../imul.js');
+var toHex = require('../utils').ToHex;
+
+// TODO: do we actually need to path the global Math object?
+if (typeof Math.imul == "undefined") {
+    Math.imul = imul;
+}
+
+// CPUs
+var FastCPU = require('./fastcpu.js');
+var SafeCPU = require('./safecpu.js');
+var SMPCPU = require('./smpcpu.js');
+
+// The asm.js ("Fast") and SMP cores must be singletons
+//  because of Firefox limitations.
+var fastcpu = null;
+var smpcpu = null;
+
+var stdlib = {
+    Int32Array : Int32Array,
+    Float32Array : Float32Array,
+    Uint8Array : Uint8Array,
+    Uint16Array : Uint16Array,
+    Math : Math
+};
+
+function createCPUSingleton(cpuname, ram, heap, ncores) {
+    var foreign = {
+        DebugMessage: message.Debug,
+        abort : message.Abort,
+        imul : Math.imul ? Math.imul : imul,
+        ReadMemory32 : ram.ReadMemory32.bind(ram),
+        WriteMemory32 : ram.WriteMemory32.bind(ram),
+        ReadMemory16 : ram.ReadMemory16.bind(ram),
+        WriteMemory16 : ram.WriteMemory16.bind(ram),
+        ReadMemory8 : ram.ReadMemory8.bind(ram),
+        WriteMemory8 : ram.WriteMemory8.bind(ram)
+    };
+    if (cpuname === 'asm') {
+        if (fastcpu === null) {
+            fastcpu = FastCPU(stdlib, foreign, heap);
+            fastcpu.Init();
+        }
+        return fastcpu;
+    } else if (cpuname === 'smp') {
+        if (smpcpu === null) {
+            smpcpu = SMPCPU(stdlib, foreign, heap);
+            smpcpu.Init(ncores);
+        }
+        return smpcpu;
+    }
+}
+
+function createCPU(cpuname, ram, heap, ncores) {
+    var cpu = null;
+
+    if (cpuname === "safe") {
+        return new SafeCPU(ram);
+    }
+    if (cpuname === "asm") {
+        cpu = createCPUSingleton(cpuname, ram, heap, ncores);
+        cpu.Init();
+        return cpu;
+    }
+    if (cpuname === "smp") {
+        cpu = createCPUSingleton(cpuname, ram, heap, ncores);
+        cpu.Init(ncores);
+        return cpu;
+    }
+    throw new Error("invalid CPU name:" + cpuname);
+}
+
+function CPU(cpuname, ram, heap, ncores) {
+    this.cpu = createCPU(cpuname, ram, heap, ncores);
+    this.name = cpuname;
+    this.ncores = ncores;
+    this.ram = ram;
+    this.heap = heap;
+
+    return this;
+}
+
+CPU.prototype.switchImplementation = function(cpuname) {
+    var oldcpu = this.cpu;
+    var oldcpuname = this.name;
+    if (oldcpuname == "smp") return;
+
+    this.cpu = createCPU(cpuname, this.ram, this.heap, this.ncores);
+
+    this.cpu.InvalidateTLB(); // reset TLB
+    var f = oldcpu.GetFlags();
+    this.cpu.SetFlags(f|0);
+    var h;
+    if (oldcpuname === "asm") {
+        h = new Int32Array(this.heap);
+        oldcpu.GetState();
+        this.cpu.pc = h[(0x40 + 0)];
+        this.cpu.nextpc = h[(0x40 + 1)];
+        this.cpu.delayedins = h[(0x40 + 2)]?true:false;
+        this.cpu.TTMR = h[(0x40 + 4)];
+        this.cpu.TTCR = h[(0x40 + 5)];
+        this.cpu.PICMR = h[(0x40 + 6)];
+        this.cpu.PICSR = h[(0x40 + 7)];
+        this.cpu.boot_dtlb_misshandler_address = h[(0x40 + 8)];
+        this.cpu.boot_itlb_misshandler_address = h[(0x40 + 9)];
+        this.cpu.current_pgd = h[(0x40 + 10)];
+    } else if (cpuname === "asm") {
+        h = new Int32Array(this.heap);
+        h[(0x40 + 0)] = oldcpu.pc;
+        h[(0x40 + 1)] = oldcpu.nextpc;
+        h[(0x40 + 2)] = oldcpu.delayedins;
+        h[(0x40 + 3)] = 0x0;
+        h[(0x40 + 4)] = oldcpu.TTMR;
+        h[(0x40 + 5)] = oldcpu.TTCR;
+        h[(0x40 + 6)] = oldcpu.PICMR;
+        h[(0x40 + 7)] = oldcpu.PICSR;
+        h[(0x40 + 8)] = oldcpu.boot_dtlb_misshandler_address;
+        h[(0x40 + 9)] = oldcpu.boot_itlb_misshandler_address;
+        h[(0x40 + 10)] = oldcpu.current_pgd;
+        this.cpu.PutState();
+    } else {
+        this.cpu.pc = oldcpu.pc;
+        this.cpu.nextpc = oldcpu.nextpc;
+        this.cpu.delayedins = oldcpu.delayedins;
+        this.cpu.TTMR = oldcpu.TTMR;
+        this.cpu.TTCR = oldcpu.TTCR;
+        this.cpu.PICMR = oldcpu.PICMR;
+        this.cpu.PICSR = oldcpu.PICSR;
+        this.cpu.boot_dtlb_misshandler_address = oldcpu.boot_dtlb_misshandler_address;
+        this.cpu.boot_itlb_misshandler_address = oldcpu.itlb_misshandler_address;
+        this.cpu.current_pgd = oldcpu.current_pgd;
+    }
+};
+
+CPU.prototype.toString = function() {
+    var r = new Uint32Array(this.heap);
+    var str = '';
+    str += "Current state of the machine\n";
+    //str += "clock: " + toHex(cpu.clock) + "\n";
+    str += "PC: " + toHex(this.cpu.pc<<2) + "\n";
+    str += "next PC: " + toHex(this.cpu.nextpc<<2) + "\n";
+    //str += "ins: " + toHex(cpu.ins) + "\n";
+    //str += "main opcode: " + toHex(cpu.ins>>>26) + "\n";
+    //str += "sf... opcode: " + toHex((cpu.ins>>>21)&0x1F) + "\n";
+    //str += "op38. opcode: " + toHex((cpu.ins>>>0)&0x3CF) + "\n";
+
+    for (var i = 0; i < 32; i += 4) {
+        str += "   r" + (i + 0) + ": " +
+            toHex(r[i + 0]) + "   r" + (i + 1) + ": " +
+            toHex(r[i + 1]) + "   r" + (i + 2) + ": " +
+            toHex(r[i + 2]) + "   r" + (i + 3) + ": " +
+            toHex(r[i + 3]) + "\n";
+    }
+    
+    if (this.cpu.delayedins) {
+        str += "delayed instruction\n";
+    }
+    if (this.cpu.SR_SM) {
+        str += "Supervisor mode\n";
+    }
+    else {
+        str += "User mode\n";
+    }
+    if (this.cpu.SR_TEE) {
+        str += "tick timer exception enabled\n";
+    }
+    if (this.cpu.SR_IEE) {
+        str += "interrupt exception enabled\n";
+    }
+    if (this.cpu.SR_DME) {
+        str += "data mmu enabled\n";
+    }
+    if (this.cpu.SR_IME) {
+        str += "instruction mmu enabled\n";
+    }
+    if (this.cpu.SR_LEE) {
+        str += "little endian enabled\n";
+    }
+    if (this.cpu.SR_CID) {
+        str += "context id enabled\n";
+    }
+    if (this.cpu.SR_F) {
+        str += "flag set\n";
+    }
+    if (this.cpu.SR_CY) {
+        str += "carry set\n";
+    }
+    if (this.cpu.SR_OV) {
+        str += "overflow set\n";
+    }
+    return str;
+};
+
+// forward a couple of methods to the CPU implementation
+var forwardedMethods = [
+    "Reset", 
+    "Step",
+    "RaiseInterrupt", 
+    "Step",
+    "AnalyzeImage",
+    "GetTicks",
+    "GetTimeToNextInterrupt",
+    "ProgressTime", 
+    "ClearInterrupt"];
+forwardedMethods.forEach(function(m) {
+    CPU.prototype[m] = function() {
+        this.cpu[m].apply(this.cpu, arguments);        
+    };
+});
+
+module.exports = CPU;

--- a/js/worker/cpu/index.js
+++ b/js/worker/cpu/index.js
@@ -7,7 +7,7 @@ var message = require('../messagehandler'); // global variable
 var imul = require('../imul.js');
 var toHex = require('../utils').ToHex;
 
-// TODO: do we actually need to path the global Math object?
+// TODO: do we actually need to patch the global Math object?
 if (typeof Math.imul == "undefined") {
     Math.imul = imul;
 }

--- a/package.json
+++ b/package.json
@@ -41,9 +41,12 @@
   "dependencies": {},
   "devDependencies": {
     "jshint": "latest",
-    "browserify": "^8.0.3"
+    "browserify": "^8.0.3",
+    "expect": "^1.3.0",
+    "lab": "^5.2.0"
   },
   "scripts": {
+    "test": "lab --ignore onmessage -v test/cpu-facade.js",
     "postinstall": "./compile"
   },
   "engines": {

--- a/test/cpu-facade.js
+++ b/test/cpu-facade.js
@@ -1,0 +1,41 @@
+// this needs to bre present in the global scope
+// for the message module
+global.onmessage = null;
+
+var RAM = require('../js/worker/ram');
+var CPU = require('../js/worker/cpu');
+
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var expect = require('expect');
+
+['safe', 'asm', 'smp'].forEach(function(cpuname) {
+    lab.test(cpuname + ' CPU can add two 32 bit registers', function (done) {
+        var memorySize = 2; // MB
+        var ramOffset = 0x100000;
+        var instructions = 5;
+        var cyclesPerInstruction = 1;
+
+        var heap = new ArrayBuffer(memorySize * 0x100000); 
+        var registers = new Uint32Array(heap);
+        var ram = new RAM(heap, ramOffset);
+        var cpu = new CPU('safe', ram, heap, 1); // 1 core
+        cpu.Reset();
+
+        registers[0] = 0x00100000;
+        registers[1] = 0x000AAAA0;
+
+        var add = 0x3 << 30 | 0x8 << 26 |
+            0x2 << 21 | // rD
+            0x0 << 16 | // rA
+            0x1 << 11;  // rB
+
+        ram.WriteMemory32(0x0100, add);
+        //console.log(cpu.toString());
+        cpu.Step(1, 1);
+        //console.log(cpu.toString());
+
+        expect(registers[2]).toEqual(0x001AAAA0);
+        done();
+    });
+});

--- a/test/cpu-facade.js
+++ b/test/cpu-facade.js
@@ -1,7 +1,9 @@
 // this needs to bre present in the global scope
 // for the message module
 global.onmessage = null;
-
+global.postMessage = function() {
+    console.log(arguments);
+}
 var RAM = require('../js/worker/ram');
 var CPU = require('../js/worker/cpu');
 
@@ -9,18 +11,21 @@ var Lab = require('lab');
 var lab = exports.lab = Lab.script();
 var expect = require('expect');
 
-['safe', 'asm', 'smp'].forEach(function(cpuname) {
+['safe', 'smp', 'asm'].forEach(function(cpuname) {
+
     lab.test(cpuname + ' CPU can add two 32 bit registers', function (done) {
         var memorySize = 2; // MB
         var ramOffset = 0x100000;
-        var instructions = 5;
-        var cyclesPerInstruction = 1;
 
         var heap = new ArrayBuffer(memorySize * 0x100000); 
         var registers = new Uint32Array(heap);
         var ram = new RAM(heap, ramOffset);
-        var cpu = new CPU('safe', ram, heap, 1); // 1 core
+        console.log('creating ' + cpuname + ' CPU');
+        var cpu = new CPU(cpuname, ram, heap, 1); // 1 core
+        console.log('done');
+        console.log('reset');
         cpu.Reset();
+        console.log('done');
 
         registers[0] = 0x00100000;
         registers[1] = 0x000AAAA0;
@@ -32,7 +37,9 @@ var expect = require('expect');
 
         ram.WriteMemory32(0x0100, add);
         //console.log(cpu.toString());
+        console.log('adding');
         cpu.Step(1, 1);
+        console.log('done');
         //console.log(cpu.toString());
 
         expect(registers[2]).toEqual(0x001AAAA0);


### PR DESCRIPTION
Moved CPU creation/implementation switching code from worker/system.js to worker/cpu/index.js.

You can now

    var CPU = require('./cpu');
    var myFastCPU = new CPU('asm", myRAM, myHeap, ncores);

without having to care about the details.

Additionally, I added a simple test for the three CPU implementations that run in node.
The tests create a CPU of each kind, load some values into two registers, write an add instruction to RAM and start the CPU for a single instruction. Then they check the value of the result register.

You can run these test with

    npm test

it should give you
✔ 1) safe CPU can add two 32 bit registers (4 ms)
✔ 2) asm CPU can add two 32 bit registers (7 ms)
✔ 3) smp CPU can add two 32 bit registers (2 ms)

Don't forget to install the dev dependencies (lab and expect) by running

    npm install

Also fixed a crashing bug when no framebuffer exists.