### PR TITLE
test/cpu-facade works now

### DIFF
--- a/js/worker/cpu/fastcpu.js
+++ b/js/worker/cpu/fastcpu.js
@@ -1,10 +1,8 @@
+var imul = require('../imul');
 
 function FastCPU(stdlib, foreign, heap) {
 "use asm";
 
-
-//var imul = stdlib.Math.imul;
-var imul = foreign.imul;
 var floor = stdlib.Math.floor;
 var DebugMessage = foreign.DebugMessage;
 var abort = foreign.abort;

--- a/js/worker/cpu/index.js
+++ b/js/worker/cpu/index.js
@@ -4,13 +4,7 @@
 
 "use strict";
 var message = require('../messagehandler'); // global variable
-var imul = require('../imul.js');
 var toHex = require('../utils').ToHex;
-
-// TODO: do we actually need to patch the global Math object?
-if (typeof Math.imul == "undefined") {
-    Math.imul = imul;
-}
 
 // CPUs
 var FastCPU = require('./fastcpu.js');
@@ -34,7 +28,6 @@ function createCPUSingleton(cpuname, ram, heap, ncores) {
     var foreign = {
         DebugMessage: message.Debug,
         abort : message.Abort,
-        imul : Math.imul ? Math.imul : imul,
         ReadMemory32 : ram.ReadMemory32.bind(ram),
         WriteMemory32 : ram.WriteMemory32.bind(ram),
         ReadMemory16 : ram.ReadMemory16.bind(ram),

--- a/js/worker/cpu/smpcpu.js
+++ b/js/worker/cpu/smpcpu.js
@@ -1,10 +1,9 @@
+var imul = require('../imul');
 
 function SMPCPU(stdlib, foreign, heap) {
 
 "use asm";
 
-//var imul = stdlib.Math.imul;
-var imul = foreign.imul;
 var floor = stdlib.Math.floor;
 var DebugMessage = foreign.DebugMessage;
 var abort = foreign.abort;

--- a/js/worker/imul.js
+++ b/js/worker/imul.js
@@ -1,4 +1,4 @@
-module.exports = function(a, b) {
+module.exports = Math.imul || function(a, b) {
     var ah  = (a >>> 16) & 0xffff;
     var al = a & 0xffff;
     var bh  = (b >>> 16) & 0xffff;

--- a/test/cpu-facade.js
+++ b/test/cpu-facade.js
@@ -11,13 +11,15 @@ var Lab = require('lab');
 var lab = exports.lab = Lab.script();
 var expect = require('expect');
 
-['safe', 'smp', 'asm'].forEach(function(cpuname) {
+['safe','smp','asm'].forEach(function(cpuname) {
 
     lab.test(cpuname + ' CPU can add two 32 bit registers', function (done) {
         var memorySize = 2; // MB
         var ramOffset = 0x100000;
 
         var heap = new ArrayBuffer(memorySize * 0x100000); 
+        var h = new Uint32Array(heap);
+
         var registers = new Uint32Array(heap);
         var ram = new RAM(heap, ramOffset);
         console.log('creating ' + cpuname + ' CPU');
@@ -29,16 +31,23 @@ var expect = require('expect');
 
         registers[0] = 0x00100000;
         registers[1] = 0x000AAAA0;
+        console.log(cpu.toString());
 
         var add = 0x3 << 30 | 0x8 << 26 |
             0x2 << 21 | // rD
             0x0 << 16 | // rA
             0x1 << 11;  // rB
-
-        ram.WriteMemory32(0x0100, add);
+        
+        var nop = 0x5 << 26 | 0x1 << 24;
+        var initialPC = 0x40040;
+        h[initialPC] = add;
+        for(var i=0; i<20000; i++)  {
+            h[initialPC + i+1] = nop;
+        }
         //console.log(cpu.toString());
         console.log('adding');
-        cpu.Step(1, 1);
+        debugger;
+        cpu.Step(64, 0);
         console.log('done');
         //console.log(cpu.toString());
 

--- a/test/cpu-facade.js
+++ b/test/cpu-facade.js
@@ -1,9 +1,9 @@
 // this needs to bre present in the global scope
 // for the message module
 global.onmessage = null;
-global.postMessage = function() {
+/*global.postMessage = function() {
     console.log(arguments);
-}
+}*/
 var RAM = require('../js/worker/ram');
 var CPU = require('../js/worker/cpu');
 
@@ -22,16 +22,16 @@ var expect = require('expect');
 
         var registers = new Uint32Array(heap);
         var ram = new RAM(heap, ramOffset);
-        console.log('creating ' + cpuname + ' CPU');
+        //console.log('creating ' + cpuname + ' CPU');
         var cpu = new CPU(cpuname, ram, heap, 1); // 1 core
-        console.log('done');
-        console.log('reset');
+        //console.log('done');
+        //console.log('reset');
         cpu.Reset();
-        console.log('done');
+        //console.log('done');
 
         registers[0] = 0x00100000;
         registers[1] = 0x000AAAA0;
-        console.log(cpu.toString());
+        //console.log(cpu.toString());
 
         var add = 0x3 << 30 | 0x8 << 26 |
             0x2 << 21 | // rD
@@ -45,10 +45,9 @@ var expect = require('expect');
             h[initialPC + i+1] = nop;
         }
         //console.log(cpu.toString());
-        console.log('adding');
-        debugger;
+        //console.log('adding');
         cpu.Step(64, 0);
-        console.log('done');
+        //console.log('done');
         //console.log(cpu.toString());
 
         expect(registers[2]).toEqual(0x001AAAA0);


### PR DESCRIPTION
Problems were:

* a step value below 64 in a call to Step() results in no instructions being executed at all in some CPU implementations (at least SMP)
* PrintState() does not return the correct values for PC and next PC in some CPU implementations (at least SMP)
* instruction code 0x0 causes an infinite loop in Step() in some CPU implementations (at least SMP)

Is there a way to control the number of instructions the CPU performs within a single call to Step()? This would be nice for writing tests. The current approach is to add a large number of NOPs and then call Step(64, some clock value): and hoping that there are enough NOPs -- that's not very nice.