### PR TITLE
Add support for restart timer mode

### DIFF
--- a/bin/jor1k-worker-min.js
+++ b/bin/jor1k-worker-min.js
@@ -2722,6 +2722,12 @@ SafeCPU.prototype.Exception = function (excepttype, addr) {
         message.Debug("Error in Exception: exception type not supported");
         message.Abort();
     }
+
+    // Handle restart mode timer
+    if (excepttype == EXCEPT_TICK && (this.TTMR >> 30) == 0x1) {
+	this.TTCR = 0;
+    }
+
     this.delayedins = false;
     this.SR_IME = false;
 };

--- a/js/worker/cpu/safecpu.js
+++ b/js/worker/cpu/safecpu.js
@@ -391,6 +391,12 @@ SafeCPU.prototype.Exception = function (excepttype, addr) {
         message.Debug("Error in Exception: exception type not supported");
         message.Abort();
     }
+
+    // Handle restart mode timer
+    if (excepttype == EXCEPT_TICK && (this.TTMR >> 30) == 0x1) {
+	this.TTCR = 0;
+    }
+
     this.delayedins = false;
     this.SR_IME = false;
 };


### PR DESCRIPTION
This adds support for the restart timer mode, which resets TTCR to zero when
an exception occurs.
Strictly speaking, the timer should restart on a match even if the exception isn't activated,
but restarting on exception probably covers most of the use cases.