### PR TITLE
Remove ".js" from module paths in require calls

### DIFF
--- a/js/master/dev/filesystem.js
+++ b/js/master/dev/filesystem.js
@@ -1,6 +1,6 @@
-var message = require('../messagehandler.js');
+var message = require('../messagehandler');
 var download = require('../../lib/download');
-var utils = require('../utils.js');
+var utils = require('../utils');
 
 "use strict";
 

--- a/js/master/dev/framebuffer.js
+++ b/js/master/dev/framebuffer.js
@@ -1,4 +1,4 @@
-var message = require('../messagehandler.js');
+var message = require('../messagehandler');
 
 
 "use strict";

--- a/js/plugins/terminal-termjs.js
+++ b/js/plugins/terminal-termjs.js
@@ -1,4 +1,4 @@
-var TermJS = require("./term.js");
+var TermJS = require("./term");
 var UTF8 = require("../lib/utf8");
 
 function TermJSTerm(termElement) {

--- a/js/worker/filesystem/filesystem.js
+++ b/js/worker/filesystem/filesystem.js
@@ -5,14 +5,14 @@
 
 "use strict";
 
-var TAR = require('./tar.js');
-var FSLoader = require('./fsloader.js');
-var utils = require('../utils.js');
-var bzip2 = require('../bzip2.js');
-var marshall = require('../dev/virtio/marshall.js');
-var UTF8 = require('../../lib/utf8.js');
+var TAR = require('./tar');
+var FSLoader = require('./fsloader');
+var utils = require('../utils');
+var bzip2 = require('../bzip2');
+var marshall = require('../dev/virtio/marshall');
+var UTF8 = require('../../lib/utf8');
 var message = require('../messagehandler');
-var LazyUint8Array = require("./lazyUint8Array.js");
+var LazyUint8Array = require("./lazyUint8Array");
 
 var S_IRWXUGO = 0x1FF;
 var S_IFMT = 0xF000;

--- a/js/worker/or1k/index.js
+++ b/js/worker/or1k/index.js
@@ -8,9 +8,9 @@ var toHex = require('../utils').ToHex;
 var imul = require('../imul');
 
 // CPUs
-var FastCPU = require('./fastcpu.js');
-var SafeCPU = require('./safecpu.js');
-var SMPCPU = require('./smpcpu.js');
+var FastCPU = require('./fastcpu');
+var SafeCPU = require('./safecpu');
+var SMPCPU = require('./smpcpu');
 
 // The asm.js ("Fast") and SMP cores must be singletons
 //  because of Firefox limitations.

--- a/js/worker/riscv/dynamiccpu.js
+++ b/js/worker/riscv/dynamiccpu.js
@@ -3,7 +3,7 @@
 // -------------------------------------------------
 var message = require('../messagehandler');
 var utils = require('../utils');
-var DebugIns = require('./disassemble.js');
+var DebugIns = require('./disassemble');
 
 
 // constructor

--- a/js/worker/riscv/fastcpu.js
+++ b/js/worker/riscv/fastcpu.js
@@ -3,7 +3,7 @@
 // -------------------------------------------------
 var message = require('../messagehandler');
 var utils = require('../utils');
-var DebugIns = require('./disassemble.js');
+var DebugIns = require('./disassemble');
 
 
 // constructor

--- a/js/worker/riscv/htif.js
+++ b/js/worker/riscv/htif.js
@@ -5,8 +5,8 @@
 "use strict";
 var message = require('../messagehandler');
 var utils = require('../utils');
-var bzip2 = require('../bzip2.js');
-var syscalls = require('./syscalls.js');
+var bzip2 = require('../bzip2');
+var syscalls = require('./syscalls');
 
 // -------------------------------------------------
 

--- a/js/worker/riscv/index.js
+++ b/js/worker/riscv/index.js
@@ -8,9 +8,9 @@ var utils = require('../utils');
 var imul = require('../imul');
 
 // CPUs
-var SafeCPU = require('./safecpu.js');
-var FastCPU = require('./fastcpu.js');
-var DynamicCPU = require('./dynamiccpu.js');
+var SafeCPU = require('./safecpu');
+var FastCPU = require('./fastcpu');
+var DynamicCPU = require('./dynamiccpu');
 
 var stdlib = {
     Int32Array : Int32Array,

--- a/js/worker/riscv/safecpu.js
+++ b/js/worker/riscv/safecpu.js
@@ -5,7 +5,7 @@
 "use strict";
 var message = require('../messagehandler');
 var utils = require('../utils');
-var DebugIns = require('./disassemble.js');
+var DebugIns = require('./disassemble');
 
 var PRV_U = 0x00;
 var PRV_S = 0x01;

--- a/js/worker/timer.js
+++ b/js/worker/timer.js
@@ -6,8 +6,8 @@
 
 "use strict";
 
-var message = require('./messagehandler.js'); // global variable
-var utils = require('./utils.js');
+var message = require('./messagehandler'); // global variable
+var utils = require('./utils');
 
 function Timer(_ticksperms, _loopspersecond) {
     // constants

--- a/js/worker/worker.js
+++ b/js/worker/worker.js
@@ -2,5 +2,5 @@
 // -------------------- Worker ---------------------
 // -------------------------------------------------
 
-var System = require('./system.js');
+var System = require('./system');
 var sys = new System();


### PR DESCRIPTION
This achieves consistency with the require calls used throughout the
source code.

This also makes it easier to use the modules with RequireJS.
One way to use RequireJS with CommonJS-style modules is by wrapping
them inside an AMD-style wrapper. The CommonJS Loader Plugin for
RequireJS (https://github.com/guybedford/cjs) does this.

However, RequireJS automatically appends ".js" to the module path,
which means a call such as "require('../messagehandler.js')" makes
RequireJS look for the file "../messagehandler.js.js", which is
clearly invalid. The simplest solution is to avoid the ".js"
altogether, which makes the path compatible with both Browserify and
RequireJS. The CJS plugin takes care of the rest.

neelabhg/sysbuild@8f1764c3d5f95d5d9e1f582c7b2c10b9bcea17bb details the
motivation for supporting RequireJS.