### PR TITLE
Revert compile script changes, restore submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sys"]
+	path = sys
+	url = https://github.com/s-macke/jor1k-sysroot.git

--- a/compile
+++ b/compile
@@ -1,13 +1,5 @@
-#!/bin/bash
+browserify -r ./js/plugins/terminal-linux.js:LinuxTerm -r ./js/master/master.js:Jor1k -o demos/jor1k-master-min.js
+browserify js/worker/worker.js -o demos/jor1k-worker-min.js
 
-rm -rf bin && mkdir bin && rm sys
-
-browserify -r ./js/plugins/terminal-linux.js:LinuxTerm -r ./js/master/master.js:Jor1k -o bin/jor1k-master-min.js
-browserify js/worker/worker.js -o bin/jor1k-worker-min.js
-
-# also need to create a symlink to sysroot 
-
-ln -s ../jor1k-sysroot sys
-
-#browserify -r ./js/plugins/terminal-linux.js:LinuxTerm -r ./js/plugins/terminal-termjs.js:TermJSTerm -r ./js/master/master.js:Jor1k -o bin/jor1k-master-min.js
+#browserify -r ./js/plugins/terminal-linux.js:LinuxTerm -r ./js/plugins/terminal-termjs.js:TermJSTerm -r ./js/master/master.js:Jor1k -o demos/jor1k-master-min.js
 

--- a/js/master/system.js
+++ b/js/master/system.js
@@ -48,8 +48,10 @@ function jor1kGUI(parameters)
     this.params.userid = this.params.userid || "";
 
     // ----------------------
-    this.worker = new Worker("jor1k/bin/jor1k-worker-min.js");
+
+    this.worker = new Worker("jor1k-worker-min.js");
     message.SetWorker(this.worker);
+
     // ----
 
     if (this.params.clipboardid) {
@@ -209,6 +211,7 @@ jor1kGUI.prototype.Reset = function () {
     this.stop = false; // VM Stopped/Aborted
     this.userpaused = false;
     this.executepending = false; // if we rec an execute message while paused      
+
     message.Send("Init", this.params.system);
     message.Send("Reset");
     message.Send("LoadAndStart", this.params.system.kernelURL);


### PR DESCRIPTION
Some unintentional changes were introduced when #109 was merged (see
https://github.com/s-macke/jor1k/pull/109#issuecomment-159967040).

This commit reverts commit cb30ffcc97b33b9bb58157a3c0a269139ac9add4
("Merge pull request cmercur2/jor1k#2 from jjang16/master"),
reversing changes made to 45cedeee46c5e5b4cd551bea3afafbfca7e72811
("adding rename to filesystem").

In particular:
* The compile script outputs into the demos folder again (instead of
  bin/)
* The compile script does not create the "sys" symlink anymore
* The "sys" submodule has been restored