### PR TITLE
Sytem clock skew

### DIFF
--- a/demos/jor1k-worker-min.js
+++ b/demos/jor1k-worker-min.js
@@ -5131,23 +5131,23 @@ FS.prototype.CheckEarlyload = function(path)
 // The filesystem is responsible to add the correct time. This is a hack
 // Have to find a better solution.
 FS.prototype.AppendDateHack = function(idx) {
-    if (this.GetFullPath(idx) != "etc/init.d/rcS") return; 
+    if (this.GetFullPath(idx) != "home/user/.profile") return;
     var inode = this.inodes[idx];
     var date = new Date();
     var datestring = 
         "\ndate -s \"" + 
-        date.getFullYear() + 
+        date.getUTCFullYear() + 
         "-" + 
-        (date.getMonth()+1) + 
+        (date.getUTCMonth()+1) + 
         "-" + 
-        date.getDate() + 
+        date.getUTCDate() + 
         " " + 
-        date.getHours() +
+        date.getUTCHours() +
         ":" + 
-        date.getMinutes() +
+        date.getUTCMinutes() +
         ":" + 
-        date.getSeconds() +
-        "\"\n";
+        date.getUTCSeconds() +
+        "\" &>/dev/null\n";
     var size = inode.size;
     this.ChangeSize(idx, size+datestring.length);
     for(var i=0; i<datestring.length; i++) {
@@ -5206,10 +5206,7 @@ FS.prototype.LoadFile = function(idx) {
             inode.data = new Uint8Array(buffer);
             if (inode.size != inode.data.length) message.Warning("Size wrong for uncompressed non-lazily loaded file: " + inode.name);
             inode.size = inode.data.length; // correct size if the previous was wrong. 
-            inode.status = STATUS_OK;
-            if (inode.name == "rcS") {
-                this.AppendDateHack(idx);
-            }
+            inode.status = STATUS_OK;            
             this.filesinloadingqueue--;
             this.HandleEvent(idx);            
         }.bind(this);
@@ -5359,6 +5356,11 @@ FS.prototype.OpenInode = function(id, mode) {
         this.LoadFile(id);
         return false;
     }
+
+    if (inode.name == ".profile") {
+        this.AppendDateHack(id);
+    }
+
     return true;
 }
 

--- a/js/worker/filesystem/filesystem.js
+++ b/js/worker/filesystem/filesystem.js
@@ -209,23 +209,23 @@ FS.prototype.CheckEarlyload = function(path)
 // The filesystem is responsible to add the correct time. This is a hack
 // Have to find a better solution.
 FS.prototype.AppendDateHack = function(idx) {
-    if (this.GetFullPath(idx) != "etc/init.d/rcS") return; 
+    if (this.GetFullPath(idx) != "home/user/.profile") return;
     var inode = this.inodes[idx];
     var date = new Date();
     var datestring = 
         "\ndate -s \"" + 
-        date.getFullYear() + 
+        date.getUTCFullYear() + 
         "-" + 
-        (date.getMonth()+1) + 
+        (date.getUTCMonth()+1) + 
         "-" + 
-        date.getDate() + 
+        date.getUTCDate() + 
         " " + 
-        date.getHours() +
+        date.getUTCHours() +
         ":" + 
-        date.getMinutes() +
+        date.getUTCMinutes() +
         ":" + 
-        date.getSeconds() +
-        "\"\n";
+        date.getUTCSeconds() +
+        "\" &>/dev/null\n";
     var size = inode.size;
     this.ChangeSize(idx, size+datestring.length);
     for(var i=0; i<datestring.length; i++) {
@@ -284,10 +284,7 @@ FS.prototype.LoadFile = function(idx) {
             inode.data = new Uint8Array(buffer);
             if (inode.size != inode.data.length) message.Warning("Size wrong for uncompressed non-lazily loaded file: " + inode.name);
             inode.size = inode.data.length; // correct size if the previous was wrong. 
-            inode.status = STATUS_OK;
-            if (inode.name == "rcS") {
-                this.AppendDateHack(idx);
-            }
+            inode.status = STATUS_OK;            
             this.filesinloadingqueue--;
             this.HandleEvent(idx);            
         }.bind(this);
@@ -437,6 +434,11 @@ FS.prototype.OpenInode = function(id, mode) {
         this.LoadFile(id);
         return false;
     }
+
+    if (inode.name == ".profile") {
+        this.AppendDateHack(id);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
There is a significant difference between files access/modified time and the system time.
![image](https://cloud.githubusercontent.com/assets/6979249/14478700/beb881e6-00dd-11e6-8769-c9db3993c69c.png)

This causes issues with programs that compare the system time with file modification time (make).


This has been fixed by changing the following:
- First to resolve the largest difference in time. The AppendDateHack now uses UTC time, making this consistent with the time zone inodes use.
- Changing when the AppendDateHack function is called and what file it appends the date to. It was moved from when the inodes are created/loaded to when the inodes are opened. This was done because after the time correction from the first issue there was still an approx. 6 second difference between the system clock and files. This is because AppendDateHack appends the current date to rcS 6 seconds before it is executed (after boot). So with the new solution (still a hack) the time is appended to '.profile' right before it is executed -- creating the smallest clock skew.

