### PR TITLE
Fix bug #125

### DIFF
--- a/js/worker/filesystem/filesystem.js
+++ b/js/worker/filesystem/filesystem.js
@@ -680,8 +680,10 @@ FS.prototype.MergeFile = function(file) {
     }
     this.inodes[ids.id].data = file.data;
     this.inodes[ids.id].size = file.data.length;
-    // Don't forget to update the modification date !
+    // Don't forget to update the timestamps !
     this.inodes[ids.id].mtime = Math.floor((new Date()).getTime()/1000);
+    this.inodes[ids.id].atime = this.inodes[ids.id].mtime;
+    this.inodes[ids.id].ctime = this.inodes[ids.id].mtime;
 }
 
 

--- a/js/worker/filesystem/filesystem.js
+++ b/js/worker/filesystem/filesystem.js
@@ -680,6 +680,8 @@ FS.prototype.MergeFile = function(file) {
     }
     this.inodes[ids.id].data = file.data;
     this.inodes[ids.id].size = file.data.length;
+    // Don't forget to update the modification date !
+    this.inodes[ids.id].mtime = Math.floor((new Date()).getTime()/1000);
 }
 
 


### PR DESCRIPTION
Hello,

I found the source of #125: `MergeFile` doesn't update the timestamps in the inode, as it should. These two commits fix that, I haven't been able to reproduce the issue since.