### PR TITLE
Allow to set custom atime and mtime

### DIFF
--- a/js/worker/dev/virtio/9p.js
+++ b/js/worker/dev/virtio/9p.js
@@ -336,12 +336,6 @@ Virtio9p.prototype.ReceiveRequest = function (ringidx, index, GetByte) {
             if (req[1] & P9_SETATTR_GID) {
                 inode.gid = req[4];
             }
-            if (req[1] & P9_SETATTR_ATIME_SET) {
-                inode.atime = req[6];
-            }
-            if (req[1] & P9_SETATTR_MTIME_SET) {
-                inode.atime = req[8];
-            }
             if (req[1] & P9_SETATTR_ATIME) {
                 inode.atime = Math.floor((new Date()).getTime()/1000);
             }
@@ -350,6 +344,12 @@ Virtio9p.prototype.ReceiveRequest = function (ringidx, index, GetByte) {
             }
             if (req[1] & P9_SETATTR_CTIME) {
                 inode.ctime = Math.floor((new Date()).getTime()/1000);
+            }
+            if (req[1] & P9_SETATTR_ATIME_SET) {
+                inode.atime = req[6];
+            }
+            if (req[1] & P9_SETATTR_MTIME_SET) {
+                inode.mtime = req[8];
             }
             if (req[1] & P9_SETATTR_SIZE) {
                 this.fs.ChangeSize(this.fids[fid].inodeid, req[5]);


### PR DESCRIPTION
`SETATTR` system calls that set a custom atime on an inode (e.g., `touch -t 0102030405 a.txt`) set both the `SETATTR_ATIME` and `SETATTR_ATIME_SET` flags.
Prior to the fix, SETATTR_ATIME_SET was processed first, setting the custom `atime` correctly.
Then, SETATTR_ATIME was processed, which updated the `atime` to the current time.

This execution order was essentially overwriting the custom `atime` immediately. The fix executes the two instructions in the correct order, and fixes a typo (an `atime` that should have been an `mtime`).


Before the fix:
```
root@host ~ >> touch -t 0102030405 a.txt                                    
root@host ~ >> stat a.txt                                                   
  File: a.txt                                                                   
  Size: 0               Blocks: 1          IO Block: 8192   regular empty file  
Device: 14h/20d Inode: 45939       Links: 1                                     
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)        
Access: 2018-02-02 23:13:29.000000000 +0000                                     
Modify: 2018-02-02 23:13:29.000000000 +0000                                     
Change: 2018-02-02 23:13:29.000000000 +0000                                     
 Birth: -           
```
After the fix:
```
root@host ~ >> touch -t 0102030405 a.txt                                    
root@host ~ >> stat a.txt                                                   
  File: a.txt                                                                   
  Size: 0               Blocks: 1          IO Block: 8192   regular empty file  
Device: 14h/20d Inode: 45939       Links: 1                                     
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)        
Access: 2001-02-03 04:05:00.000000000 +0000                                     
Modify: 2001-02-03 04:05:00.000000000 +0000                                     
Change: 2001-02-03 04:05:00.000000000 +0000                                     
 Birth: -  
```


(Thanks for an awesome project!)