### PR TITLE
Add networking bugtracker to main demo page

### DIFF
--- a/demos/main.html
+++ b/demos/main.html
@@ -66,7 +66,8 @@
                 <li><a href="https://github.com/s-macke/jor1k/wiki/Explore-the-emulator">Explore the emulator</a> wiki page</li>
                 <li><a href="http://www.benjamincburns.com/2013/11/10/jor1k-ethmac-support.html">Ben's blog post about network support</a></li>
                 <li><a href="https://github.com/s-macke/jor1k/">Project</a> page at github</li>
-                <li><a href="https://github.com/s-macke/jor1k/issues">Bugtracker</a> to report any issues or feature requests</li>
+                <li><a href="https://github.com/s-macke/jor1k/issues">Emulator Bugtracker</a> to report any emulator issues or feature requests</li>
+                <li><a href="https://github.com/benjamincburns/websockproxy/issues">Networking Bugtracker</a> to report network outages or other problems related to the demo network</li>
                 <li><a href="https://github.com/s-macke/jor1k/wiki">Wiki</a> containing more detailed descriptions</li>
                 <li><a href="http://openrisc.io">Official site</a> of the openrisc project</li>
             </ul>
@@ -75,17 +76,17 @@
             <ul>
                 <li class="contributor">
                     <ul>
-                        <li class="contributor-info">Main developer - Sebastian Macke <a href="http://simulationcorner.net/">simulationcorner.net</a></li>
+                        <li class="contributor-info">Main developer - Sebastian Macke <a href="https://simulationcorner.net/">simulationcorner.net</a></li>
                     </ul>
                 </li>
                 <li class="contributor">
                     <ul>
-                        <li class="contributor-info">Network support - Ben Burns <a href="http://www.benjamincburns.com">benjamincburns.com</a></li>
+                        <li class="contributor-info">Network support - Ben Burns <a href="https://www.benjamincburns.com">benjamincburns.com</a></li>
                     </ul>
                 </li>
                 <li class="contributor">
                     <ul>
-                        <li class="contributor-info">Gerard Braad <a href="http://gbraad.nl">gbraad.nl</a></li>
+                        <li class="contributor-info">Gerard Braad <a href="https://gbraad.nl">gbraad.nl</a></li>
                     </ul>
                 </li>
                 <li class="contributor">


### PR DESCRIPTION
Should help to direct people to the [`websockproxy` issue tracker](https://github.com/benjamincburns/websockproxy/issues) when reporting network problems.